### PR TITLE
feat: バトル詳細ページと参加ボタンの機能追加

### DIFF
--- a/frontend/app/(root)/battles/[id]/page.tsx
+++ b/frontend/app/(root)/battles/[id]/page.tsx
@@ -4,7 +4,6 @@ import { getCurrentUser } from "@/utils/getCurrentUser";
 import BattleDetail from "@/features/BattleDetail";
 import { redirect } from "next/navigation";
 import { callApi } from "@/utils/callApi";
-import { toast } from "sonner";
 
 const BattleDetailPage = async (
   {
@@ -19,7 +18,7 @@ const BattleDetailPage = async (
   if (!currentUser || !currentUser?.success) {
     redirect("/login");
   }
-
+  
   const battleId = id
   const battle = await callApi(`/battles/${battleId}`, {
     method: "GET",
@@ -30,7 +29,7 @@ const BattleDetailPage = async (
     <>
       <PageHeader backLink="/" title={battle?.data.title}/>
       <ContentContainer>
-        <BattleDetail battle={battle?.data}/>
+        <BattleDetail battle={battle?.data} currentUserId={currentUser?.data.id}/>
       </ContentContainer>
     </>
   )

--- a/frontend/app/(root)/profile/settings/page.tsx
+++ b/frontend/app/(root)/profile/settings/page.tsx
@@ -13,7 +13,7 @@ const ProfileEditPage = async () => {
 
   return (
     <>
-      <PageHeader backLink="/" title="プロフィール設定"/>
+      <PageHeader backLink="/profile" title="プロフィール設定"/>
       <ContentContainer>
         <ProfileSettings user={currentUser.data}/>
       </ContentContainer>

--- a/frontend/features/BattleDetail/components/FavoriteButton.tsx
+++ b/frontend/features/BattleDetail/components/FavoriteButton.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { useSwitchState } from "@/hooks/useSwitchState";
 import { createFavorite, deleteFavorite } from "@/server/actions/favorite/action";
-import { useState } from "react";
 import { FaRegStar, FaStar } from "react-icons/fa6";
-import { toast } from "sonner"
 
 interface FavoriteButtonProps {
   isFavorite: boolean;
@@ -12,30 +11,12 @@ interface FavoriteButtonProps {
 }
 
 const FavoriteButton = ({isFavorite, battleId}:FavoriteButtonProps) => {
-  const [isFavoriteState, setIsFavoriteState] = useState(isFavorite);
-
-  const handleCreateFavorite = createFavorite.bind(null, battleId.toString());
-  const handleDeleteFavorite = deleteFavorite.bind(null, battleId.toString());
-
-  const handleFavorite = async () => {
-    if (isFavoriteState) {
-      const response = await handleDeleteFavorite();
-
-      if(response?.success !== undefined && !response.success) {
-        toast.error(response.message, { style: { background: "#dc2626", color: "#fff" }});
-      } else {
-        setIsFavoriteState(false);
-      }
-    } else {
-      const response = await handleCreateFavorite();
-      
-      if(response?.success !== undefined && !response.success) {
-        toast.error(response.message, { style: { background: "#dc2626", color: "#fff" }});
-      } else {
-        setIsFavoriteState(true);
-      }
-    }
-  }
+  const {isSwitchState: isFavoriteState, handleSwitchState: handleFavorite} = useSwitchState(
+    battleId.toString(),
+    isFavorite,
+    createFavorite,
+    deleteFavorite
+  )
 
   return (
     <form action={handleFavorite}>

--- a/frontend/features/BattleDetail/components/ParticipantButton.tsx
+++ b/frontend/features/BattleDetail/components/ParticipantButton.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { Button } from '@/components/ui/button'
+import { useSwitchState } from '@/hooks/useSwitchState'
+import { createParitipant, deleteParitipant } from '@/server/actions/participant/actions'
+
+interface ParticipantButtonProps {
+  isParticipant: boolean,
+  battleId: number
+}
+
+const ParticipantButton = ({battleId, isParticipant}: ParticipantButtonProps) => {
+  console.log("isParticipant", isParticipant)
+  const {isSwitchState: isParicipantState, handleSwitchState: handleParticipant} = useSwitchState(
+    battleId.toString(),
+    isParticipant,
+    createParitipant,
+    deleteParitipant,
+    true
+  )
+  return (
+    <form action={handleParticipant}>
+      {isParicipantState ? (
+        <Button type="submit" className="bg-white border border-vieolet-500 rounded-full w-full text-violet-500 py-7 text-[18px] cursor-pointer hover:opacity-70">この対戦から退出する</Button>
+      ):(
+        <Button type="submit" className="bg-violet-500 border border-vieolet-500 rounded-full w-full text-white py-7 text-[18px] cursor-pointer hover:opacity-70">この対戦に参加する</Button>
+      )}
+    </form>
+    
+  )
+}
+
+export default ParticipantButton

--- a/frontend/features/BattleDetail/index.tsx
+++ b/frontend/features/BattleDetail/index.tsx
@@ -4,13 +4,16 @@ import { formatDate, formatDateTime, formatPeriod } from "@/lib/formatDate";
 import Image from "next/image";
 import { FaCrown } from "react-icons/fa6";
 import FavoriteButton from "./components/FavoriteButton";
+import ParticipantButton from "./components/ParticipantButton";
 
 interface BattleDetailProps {
   battle: BattleDetail;
+  currentUserId: number;
 }
 
-const index = async ({battle}: BattleDetailProps) => {
-  console.log(battle, "バトル詳細");
+const index = async ({battle, currentUserId}: BattleDetailProps) => {
+  const isHost = currentUserId=== battle.host_user_id;
+  const isParticipant = battle.participants.some((participant) => participant.user_id === currentUserId);
   return (
     <div className="p-3">
       <div>
@@ -74,7 +77,7 @@ const index = async ({battle}: BattleDetailProps) => {
         <p className="text-sm">{battle.detail}</p>
       </div>
       <div className="mt-4">
-        <Button className="bg-violet-500 border border-vieolet-500 rounded-full w-full text-white py-7 text-[18px] cursor-pointer hover:opacity-70">この対戦に参加する</Button>
+        {!isHost && (<ParticipantButton battleId={battle.id} isParticipant={isParticipant}/>)}
       </div>
     </div>
   )

--- a/frontend/hooks/useSwitchState.ts
+++ b/frontend/hooks/useSwitchState.ts
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface AsyncFunc {
+  (battleId: string): Promise<{ success: boolean; message: string }>;
+}
+
+export const useSwitchState = (
+  battleId: string,
+  isState: boolean,
+  createFunc: AsyncFunc,
+  deleteFunc: AsyncFunc,
+  isSuccessToast: boolean = false,
+) => {
+  const [isSwitchState, setIsSwitchState] = useState(isState);
+
+  const handleCreate = createFunc.bind(null, battleId);
+  const handleDelete = deleteFunc.bind(null, battleId);
+
+  const handleSwitchState = async () => {
+    if (isSwitchState) {
+      const response = await handleDelete();
+
+      if(response?.success !== undefined && !response.success) {
+        toast.error(response.message, { style: { background: "#dc2626", color: "#fff" }});
+      } else {
+        if(isSuccessToast) {
+          toast.success(response.message, { style: { background: "#4ade80", color: "#fff" }});
+        }
+        setIsSwitchState(false);
+      }
+    } else {
+      const response = await handleCreate();
+      
+      if(response?.success !== undefined && !response.success) {
+        toast.error(response.message, { style: { background: "#dc2626", color: "#fff" }});
+      } else {
+        if(isSuccessToast) {
+          toast.success(response.message, { style: { background: "#4ade80", color: "#fff" }});
+        }
+        setIsSwitchState(true);
+      }
+    }
+  }
+
+  return {
+    isSwitchState,
+    setIsSwitchState,
+    handleSwitchState,
+  }
+}

--- a/frontend/server/actions/participant/actions.ts
+++ b/frontend/server/actions/participant/actions.ts
@@ -3,8 +3,8 @@
 
 import { callApi } from "@/utils/callApi";
 
-export const createFavorite = async(battleId:string) => {
-  const response = await callApi(`/battles/${battleId}/favorites`, {
+export const createParitipant = async(battleId:string) => {
+  const response = await callApi(`/battles/${battleId}/participants`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -20,12 +20,12 @@ export const createFavorite = async(battleId:string) => {
 
   return {
     success: true,
-    message: "お気に入りに追加しました",
+    message: "バトルに参加しました",
   }
 }
 
-export const deleteFavorite = async(battleId:string) => {
-  const response = await callApi(`/battles/${battleId}/favorites`, {
+export const deleteParitipant = async(battleId:string) => {
+  const response = await callApi(`/battles/${battleId}/participants`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -41,6 +41,6 @@ export const deleteFavorite = async(battleId:string) => {
 
   return {
     success: true,
-    message: "お気に入りを削除しました",
+    message: "バトルから退出しました",
   }
 }

--- a/frontend/types/user/types.ts
+++ b/frontend/types/user/types.ts
@@ -1,5 +1,5 @@
 interface User {
-  id: string;
+  id: number;
   name: string;
   email: string;
   image_url: string;


### PR DESCRIPTION
- バトル詳細ページに現在のユーザーIDを渡すように変更
- FavoriteButtonコンポーネントをuseSwitchStateフックを使用するようにリファクタリング
- 新しいParticipantButtonコンポーネントを追加し、バトルへの参加/退出機能を実装
- useSwitchStateフックを新規作成し、状態管理を簡素化
- サーバーアクションに参加者の追加/削除機能を実装
- UserインターフェースのID型をstringからnumberに変更